### PR TITLE
bump hyperledger/besu to 26.4.0, dappnode/staker-package-scripts to v0.1.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "upstream": [
     {
-      "version": "26.2.0",
+      "version": "26.4.0",
       "repo": "hyperledger/besu",
       "arg": "UPSTREAM_VERSION"
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: besu
       args:
-        UPSTREAM_VERSION: 26.2.0
+        UPSTREAM_VERSION: 26.4.0
         STAKER_SCRIPTS_VERSION: v0.1.2
         DATA_DIR: /var/lib/besu
     volumes:


### PR DESCRIPTION
Bumps upstream version

- [hyperledger/besu](https://github.com/hyperledger/besu) from 26.2.0 to [26.4.0](https://github.com/hyperledger/besu/releases/tag/26.4.0)
- [dappnode/staker-package-scripts](https://github.com/dappnode/staker-package-scripts) from v0.1.2 to [v0.1.2](https://github.com/dappnode/staker-package-scripts/releases/tag/v0.1.2)